### PR TITLE
Update README for arrow dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Python setups as well. Hagelslag requires the following packages and recommends 
 * matplotlib >= 1.4
 * scikit-learn >= 0.16
 * pandas >= 0.15
+* arrow >= 0.8.0
 * basemap
 * netCDF4-python
 


### PR DESCRIPTION
When modifying the WRFModelGrid object to allow for idealized model
data (see 82331e89cd267b568816a358b1e0fa2a0beb9bba), a dependency on the
arrow package was added. This dependency was reflected in the setup.py
script, but not the README.