### PR TITLE
Changed pd.read_table to pd.read_csv

### DIFF
--- a/config/ncar_storm_data_3km.config
+++ b/config/ncar_storm_data_3km.config
@@ -8,7 +8,7 @@ from datetime import datetime
 
 work_path = "/glade/p/work/dgagne/"
 scratch_path = "/glade/scratch/dgagne/"
-dates = pd.read_table("/glade/u/home/dgagne/hagelslag/config/ncar_storm_dates_3km_restart.txt",
+dates = pd.read_csv("/glade/u/home/dgagne/hagelslag/config/ncar_storm_dates_3km_restart.txt",
                       header=None)[0].astype(str).str.pad(14, side="right",fillchar="0")
 date_index = pd.DatetimeIndex(dates)
 ensemble_members = ["d01"]


### PR DESCRIPTION
To avoid this warning:
FutureWarning: read_table is deprecated, use read_csv instead, passing
sep='\t'.