### PR TITLE
Fixed issue in find_model_patch_tracks

### DIFF
--- a/hagelslag/processing/TrackProcessing.py
+++ b/hagelslag/processing/TrackProcessing.py
@@ -137,13 +137,17 @@ class TrackProcessor(object):
         if self.model_grid.data is None:
             print("No model output found")
             return tracked_model_objects
-        min_orig = self.model_ew.min_intensity
-        max_orig = self.model_ew.max_intensity
-        data_increment_orig = self.model_ew.data_increment
         if self.segmentation_approach == "ew":
+            min_orig = self.model_ew.min_intensity
+            max_orig = self.model_ew.max_intensity
+            data_increment_orig = self.model_ew.data_increment
             self.model_ew.min_intensity = 0
             self.model_ew.data_increment = 1
             self.model_ew.max_intensity = 100
+        else:
+            min_orig = 0
+            max_orig = 1
+            data_increment_orig = 1
         for h, hour in enumerate(self.hours):
             # Identify storms at each time step and apply size filter
             print("Finding {0} objects for run {1} Hour: {2:02d}".format(self.ensemble_member,
@@ -163,6 +167,7 @@ class TrackProcessor(object):
                                                   min_area=self.size_filter, max_area=self.model_ew.max_size,
                                                   max_range=self.model_ew.delta, increment=self.model_ew.data_increment,
                                                   gaussian_sd=self.gaussian_window)
+                del scaled_data
             else:
                 hour_labels = label_storm_objects(model_data, self.segmentation_approach,
                                                   self.model_ew.min_intensity, self.model_ew.max_intensity,
@@ -175,7 +180,7 @@ class TrackProcessor(object):
                 dims = model_obj.timesteps[-1].shape
                 if h > 0:
                     model_obj.estimate_motion(hour, self.model_grid.data[h-1], dims[1], dims[0])
-            del scaled_data
+
             del model_data
             del hour_labels
         tracked_model_objects.extend(track_storms(model_objects, self.hours,

--- a/test/test_tracking.py
+++ b/test/test_tracking.py
@@ -3,11 +3,13 @@ import numpy as np
 from datetime import datetime, timedelta
 from hagelslag.data.ModelOutput import ModelOutput
 from hagelslag.processing.tracker import label_storm_objects, extract_storm_objects
+from hagelslag.processing.TrackProcessing import TrackProcessor
+from hagelslag.processing.ObjectMatcher import shifted_centroid_distance, centroid_distance, time_distance
 
 
 class TestTracking(unittest.TestCase):
     def setUp(self):
-        self.model_path = "testdata/spring2015_unidata/"
+        self.model_path = "../testdata/spring2015_unidata/"
         self.ensemble_name = "SSEF"
         self.member ="wrf-s3cn_arw"
         self.run_date = datetime(2015, 6, 4)
@@ -16,6 +18,7 @@ class TestTracking(unittest.TestCase):
         self.end_hour = 24
         self.start_date = self.run_date + timedelta(hours=self.start_hour)
         self.end_date = self.run_date + timedelta(hours=self.end_hour)
+        self.map_file = "../mapfiles/ssef2015.map"
         self.model_grid = ModelOutput(self.ensemble_name,
                                  self.member,
                                  self.run_date,
@@ -23,18 +26,18 @@ class TestTracking(unittest.TestCase):
                                  self.start_date,
                                  self.end_date,
                                  self.model_path,
-                                 "mapfiles/ssef2015.map",
+                                 self.map_file,
                                  single_step=False)
         self.model_grid.load_data()
-        self.model_grid.load_map_info("mapfiles/ssef2015.map")
+        self.model_grid.load_map_info(self.map_file)
 
     def test_model_grid_loading(self):
-
-        self.assertEquals(self.model_grid.lat.shape, self.model_grid.lon.shape,
-                          "Lat and Long grids are not equal shaped.")
-        self.assertEquals(self.model_grid.data.shape[1:], self.model_grid.lat.shape,
+        print(self.model_grid.lat.shape, self.model_grid.lon.shape)
+        self.assertEqual(self.model_grid.lat.shape[0], self.model_grid.lon.shape[0],
+                          "Lat and Long grids are not equal shaped. {")
+        self.assertEqual(self.model_grid.data.shape[1:], self.model_grid.lat.shape,
                           "Data shape does not match map shape.")
-        self.assertEquals(self.end_hour - self.start_hour + 1, self.model_grid.data.shape[0],
+        self.assertEqual(self.end_hour - self.start_hour + 1, self.model_grid.data.shape[0],
                           "Number of hours loaded does not match specified hours.")
 
     def test_object_identification(self):
@@ -47,3 +50,21 @@ class TestTracking(unittest.TestCase):
         storm_objs = extract_storm_objects(label_grid, self.model_grid.data[0], self.model_grid.x,
                                            self.model_grid.y, np.array([0]))
         self.assertEquals(len(storm_objs[0]), label_grid.max(), "Storm objects do not match number of labeled objects")
+
+    def test_track_processing(self):
+        ws_params = (25, 50)
+        object_matcher_params = ([shifted_centroid_distance], np.array([1.0]),
+                             np.array([24000]))
+        track_matcher_params = ([centroid_distance, time_distance],
+                                     np.array([80000, 2]))
+        size_filter = 10
+        gaussian_window = 1
+        tp = TrackProcessor(self.run_date, self.start_date, self.end_date, self.ensemble_name,
+                            self.member, self.variable, self.model_path, self.map_file, ws_params,
+                            object_matcher_params, track_matcher_params, size_filter, gaussian_window,
+                            segmentation_approach="ws", single_step=False
+                            )
+        track_model_patch_objects = tp.find_model_patch_tracks()
+        track_model_objects = tp.find_model_tracks()
+        self.assertGreater(len(track_model_objects), 0, "No objects found")
+        self.assertGreater(len(track_model_patch_objects), 0, "No patch objects found")


### PR DESCRIPTION
I fixed the other issue Dave brought up with find_model_patch_tracks. I also added a unit test for the problem and confirmed that everything runs with a nonwatershed algorithm in TrackProcessor.