### PR TITLE
Cores are >= max_intensity not <=

### DIFF
--- a/hagelslag/processing/Watershed.py
+++ b/hagelslag/processing/Watershed.py
@@ -19,7 +19,7 @@ class Watershed(object):
         self.max_intensity = max_intensity
 
     def label(self, data):
-        core_labels, n_labels = label(data <= self.max_intensity)
+        core_labels, n_labels = label(data >= self.max_intensity)
         ws_labels = watershed(data.max() - data, markers=core_labels, mask=data >= self.min_intensity)
         return ws_labels
 


### PR DESCRIPTION
I can see why the greater-than-or-equal sign looks wrong, because one is
asking to find pixels greater than a "maximum". However, that's okay.
You actually have pixels greater than the maximum. Maximum isn't the
maximum in the image, it is the minimum intensity of a convective core.

This needs to be reverted to >=. Not <= . The convective cores are
indeed >= max_intensity.
I found this bug after the watershed approach started grouping the whole
image into a single label.